### PR TITLE
 Make list items starting with plus fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ Or, if you find it cleaner, like this:
 ```markdown
 # Slide
 
--[+] This
--[+] will
--[+] come one by one
++ This
++ will
++ come one by one
 ```
 
 ### Slide backgrounds

--- a/_layouts/reveal.html
+++ b/_layouts/reveal.html
@@ -48,7 +48,8 @@
 				{% for post in site.posts reversed %}
 				<section data-markdown data-separator="^\n---\n$" data-separator-vertical="^\n--\n$" data-notes="^Note:">
 					<script type="text/template">
-						{{ post.content | replace:'<fragment/>','<!-- .element: class="fragment" -->' | replace:'<background>','<!-- .slide: data-background="' | replace:'</background>','" -->' | replace:'-[+]','- <!-- .element: class="fragment" -->' }}
+						{% assign lines = post.content | newline_to_br | strip_newlines | split: "<br />" %}{% for line in lines %}{% assign processed_line = line | replace:'<fragment/>','<!-- .element: class="fragment" -->' | replace:'<background>','<!-- .slide: data-background="' | replace:'</background>','" -->' %}{% assign first_char = line | slice: 0,1 %}{% if first_char == '+' %}{% assign processed_line = processed_line | replace_first: '+','' | prepend: '+ <!-- .element: class="fragment" -->' %}{% endif %}{{ processed_line }}{% comment %}Following line break is important{% endcomment %}
+{% endfor %}
 					</script>
 				</section>
 				{% endfor %}

--- a/_layouts/reveal.html
+++ b/_layouts/reveal.html
@@ -48,8 +48,30 @@
 				{% for post in site.posts reversed %}
 				<section data-markdown data-separator="^\n---\n$" data-separator-vertical="^\n--\n$" data-notes="^Note:">
 					<script type="text/template">
-						{% assign lines = post.content | newline_to_br | strip_newlines | split: "<br />" %}{% for line in lines %}{% assign processed_line = line | replace:'<fragment/>','<!-- .element: class="fragment" -->' | replace:'<background>','<!-- .slide: data-background="' | replace:'</background>','" -->' %}{% assign first_char = line | slice: 0,1 %}{% if first_char == '+' %}{% assign processed_line = processed_line | replace_first: '+','' | prepend: '+ <!-- .element: class="fragment" -->' %}{% endif %}{{ processed_line }}{% comment %}Following line break is important{% endcomment %}
-{% endfor %}
+{%
+						assign lines = post.content | newline_to_br | strip_newlines | split: "<br />"
+%}{%
+						for line in lines
+%}{% 
+							assign processed_line = line
+								| replace:'<fragment/>','<!-- .element: class="fragment" -->'
+								| replace:'<background>','<!-- .slide: data-background="'
+								| replace:'</background>','" -->'
+%}{%
+							assign first_char = line
+								| slice: 0,1
+%}{%
+							if first_char == '+'
+%}{%
+								assign processed_line = processed_line
+									| replace_first: '+',''
+									| prepend: '+ <!-- .element: class="fragment" -->'
+%}{%
+							endif
+							%}{{ processed_line }}{% comment %}Following line break is important{% endcomment %}
+{%
+						endfor
+%}
 					</script>
 				</section>
 				{% endfor %}

--- a/_posts/0000-01-03-fragments.md
+++ b/_posts/0000-01-03-fragments.md
@@ -2,8 +2,9 @@
 
 It's also possible to do fragments.
 
-- You can use &lt;fragment/&gt; to step your list items
-- like <fragment/>
-- this <fragment/>
--[+] or use ‘&dash;[+]’ instead of ‘-’ for your item like this:  
-  &dash;[+] this is a fragment
+- Start the line with ‘+’ instead of ‘-’ for your fragment item like this:  
+  `+ This is a fragment`
++ This is a fragment
++ Your fragment may contain the ‘+’ character
+
+<fragment/>You can use &lt;fragment/&gt; to step other content.


### PR DESCRIPTION
(please comment on https://github.com/dploeger/jekyll-revealjs/pull/26)

This introduces some hacky Liquid code to get around the limitations
of the filters available. It’s not possible to use regular expressions
in replacements, so only replacing `+` at the start of a line requires
looping over each line inspecting a substring of the line on each
iteration.

In addition it is not easy to iterate over each line. You have to first
convert newlines to breaks, then split by those, then add the newlines
back in to avoid impacting the formatting. This is considerable extra
complexity but the trade-off is neater markup in the slides at the
expense of less functional Liquid.

I’ve removed the `-[+]` notation in favour of this simpler version.